### PR TITLE
PMT Template Validation Rules (Cayan)

### DIFF
--- a/sfdc-pmt/main/default/objects/PMT_Phase__c/validationRules/Protect_Template_Phases_with_Permissions.validationRule-meta.xml
+++ b/sfdc-pmt/main/default/objects/PMT_Phase__c/validationRules/Protect_Template_Phases_with_Permissions.validationRule-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Protect_Template_Phases_with_Permissions</fullName>
+    <active>true</active>
+    <description>PMT Projects marked as templates should only be editable if a User has the PMT Template Author permissions. This includes Phases of Templates. Currently only enforced on CAYAN specific templates.</description>
+    <errorConditionFormula>AND(Project__r.IsTemplate__c,  Project__r.RecordType.DeveloperName == &apos;Cayan&apos;, NOT($Permission.PMT_Template_Author))</errorConditionFormula>
+    <errorMessage>Only Template Authors can Create/Modify a Project Template.</errorMessage>
+</ValidationRule>

--- a/sfdc-pmt/main/default/objects/PMT_Project__c/validationRules/Protect_Templates_behind_Permissions.validationRule-meta.xml
+++ b/sfdc-pmt/main/default/objects/PMT_Project__c/validationRules/Protect_Templates_behind_Permissions.validationRule-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Protect_Templates_behind_Permissions</fullName>
+    <active>true</active>
+    <description>PMT Projects marked as templates should only be editable if a User has the PMT Template Author permissions. Currently only enforced on CAYAN specific templates.</description>
+    <errorConditionFormula>AND(IsTemplate__c,  RecordType.DeveloperName == &apos;Cayan&apos;,  NOT($Permission.PMT_Template_Author))</errorConditionFormula>
+    <errorMessage>Only Template Authors can Create/Modify a Project Template.</errorMessage>
+</ValidationRule>

--- a/sfdc-pmt/main/default/objects/PMT_Task__c/validationRules/Protect_Template_Tasks_with_Permissions.validationRule-meta.xml
+++ b/sfdc-pmt/main/default/objects/PMT_Task__c/validationRules/Protect_Template_Tasks_with_Permissions.validationRule-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Protect_Template_Tasks_with_Permissions</fullName>
+    <active>true</active>
+    <description>PMT Projects marked as templates should only be editable if a User has the PMT Template Author permissions. This includes the Tasks related to a Template. Currently only enforced on CAYAN specific templates.</description>
+    <errorConditionFormula>AND(IsTemplate__c,  Phase__r.Project__r.RecordType.DeveloperName  == &apos;Cayan&apos;, NOT($Permission.PMT_Template_Author))</errorConditionFormula>
+    <errorMessage>Only Template Authors can Create/Modify a Project Template.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
Created validation rules on the Project/Phase/Task in regards to Templates. Utilizes the 'PMT_Template_Author' custom permission

AB#72196 